### PR TITLE
stripping leading / from s3 keys

### DIFF
--- a/piprepo/__init__.py
+++ b/piprepo/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.0.3'
+__version__ = '0.0.4'
 __description__ = 'piprepo creates PEP-503 compliant package repositories.'

--- a/piprepo/models.py
+++ b/piprepo/models.py
@@ -146,6 +146,9 @@ class S3Index(Index):
 
     # hidden helper methods
     def _put_object(self, filename, content_type):
-        key = self.prefix + filename.split(self.source)[1][1:] #strip / from path name
+        if self.prefix:
+            key = self.prefix + filename.split(self.source)[1]
+        else:
+            key = self.prefix + filename.split(self.source)[1].lstrip('/')
         body = open(filename, 'rb')
         self.bucket.put_object(Key=key, Body=body, ContentType=content_type)

--- a/piprepo/models.py
+++ b/piprepo/models.py
@@ -146,6 +146,6 @@ class S3Index(Index):
 
     # hidden helper methods
     def _put_object(self, filename, content_type):
-        key = self.prefix + filename.split(self.source)[1]
+        key = self.prefix + filename.split(self.source)[1][1:] #strip / from path name
         body = open(filename, 'rb')
         self.bucket.put_object(Key=key, Body=body, ContentType=content_type)


### PR DESCRIPTION
Current implementation starts all keys with / creating an unnamed prefix in s3. 