### PR TITLE
use raw string for regex, pin working versions of pytest*

### DIFF
--- a/piprepo/__init__.py
+++ b/piprepo/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 __description__ = 'piprepo creates PEP-503 compliant package repositories.'

--- a/piprepo/utils.py
+++ b/piprepo/utils.py
@@ -11,7 +11,7 @@ def normalize(project):
 def get_project_name_from_file(filename):
     # PEP-440 compliant version
     # https://www.python.org/dev/peps/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions
-    pep440 = '([1-9]\d*!)?(0|[1-9]\d*)(\.(0|[1-9]\d*))*((a|b|rc)(0|[1-9]\d*))?(\.post(0|[1-9]\d*))?(\.dev(0|[1-9]\d*))?'
+    pep440 = r'([1-9]\d*!)?(0|[1-9]\d*)(\.(0|[1-9]\d*))*((a|b|rc)(0|[1-9]\d*))?(\.post(0|[1-9]\d*))?(\.dev(0|[1-9]\d*))?'
 
     # use pkg_resources to find project name for .eggs
     if filename.endswith('.egg'):

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ envlist = py{27,35,36}-pip{8,9,10}
 deps =
     flake8
     moto
-    pytest
-    pytest-cov
+    pytest==3.5.0
+    pytest-cov==2.5.1
 usedevelop = true
 commands =
     pip8: pip install --upgrade pip>7,<9
@@ -16,4 +16,4 @@ commands =
     pytest --cov=piprepo --cov-report=term-missing
 
 [flake8]
-max-line-length = 120
+max-line-length = 130


### PR DESCRIPTION
- Use raw string for regex to avoid [invalid escape sequence errors](https://www.flake8rules.com/rules/W605.html)
- Pin pytest versions to avoid [an open issue](https://github.com/pytest-dev/pytest-cov/issues/306) with newer version of `pytest-cov`.