### PR TITLE
Enable PEP-592 support for local indexes

### DIFF
--- a/piprepo/utils.py
+++ b/piprepo/utils.py
@@ -21,3 +21,6 @@ def get_project_name_from_file(filename):
         return normalize(match.group(1))
     # raise an exception if filename is not a valid python package
     raise InvalidFileName(filename)
+
+def get_yank_reason_package_tag(filename, reason):
+    return '{}" data-yank="{}"'.format(filename, reason)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,9 @@ PACKAGES = [
     'affinitic.recipe.fakezope2eggs-0.3-py2.4.egg',
     'foursquare-1!2016.9.12.tar.gz'
 ]
+YANKED_PACKAGES = {
+    'foursquare-1!2016.9.12.tar.gz.yank': 'yanked because of reasons',
+}
 
 
 @pytest.yield_fixture(scope="function")
@@ -19,6 +22,7 @@ def tempindex():
     temp = tempfile.mkdtemp()
     index = {
         'packages': PACKAGES,
+        'yanked_packages': YANKED_PACKAGES,
         'source': os.path.join(temp, 'source'),
         'destination': os.path.join(temp, 'destination'),
     }
@@ -27,5 +31,8 @@ def tempindex():
     for package in index['packages']:
         with open(os.path.join(index['source'], package), 'w') as f:
             f.write(package)
+    for package, yank_reason in index['yanked_packages'].items():
+        with open(os.path.join(index['source'], package), 'w') as f:
+            f.write(yank_reason)
     yield index
     shutil.rmtree(temp)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -4,7 +4,7 @@ import pytest
 import sys
 from moto import mock_s3
 from piprepo import command
-from piprepo.utils import get_project_name_from_file
+from piprepo.utils import get_project_name_from_file, get_yank_reason_package_tag
 from .test_s3 import assert_s3_bucket_contents
 
 
@@ -27,7 +27,10 @@ def test_build(tempindex):
         with open(os.path.join(tempindex['source'], 'simple', 'index.html')) as f:
             assert get_project_name_from_file(package) in f.read()
         with open(index, 'r') as f:
-            assert package in f.read()
+            package_version_list = f.read()
+            assert package in package_version_list
+            if package + '.yank' in tempindex['yanked_packages'].keys():
+                assert get_yank_reason_package_tag(package, tempindex['yanked_packages'][package + '.yank']) in package_version_list
 
 
 def test_dir_sync(tempindex):


### PR DESCRIPTION
Hi,

This PR enables PEP-592 (yanking) support.

You can use it by creating `$filename.yank` in the repository directory. The presence of one of these files will trigger a `data-yank` attribute on the corresponding line in the index.

Currently it only works for local indexes, since the `.yank` file needs to be read to get the reason. Yank reasons should not contain `"`, as the html attributes are currently unescaped.