### PR TITLE
Remove pip from dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     entry_points={
         'console_scripts': ['piprepo=piprepo.command:main'],
     },
-    install_requires=['pip>=8', 'boto3'],
+    install_requires=['boto3'],
     extras_require={
         'dev': ['flake8', 'pytest', 'pytest-cov', 'moto']
     },


### PR DESCRIPTION
Having a runtime dependency on pip is generally not desirable, especially when one wants to pin all their dependencies using a tool such as [pip-compile](https://github.com/jazzband/pip-tools/).

Piprepo does not depend on pip, remove the dependency from setup.py.